### PR TITLE
Use fluent naming for lighter and darker.

### DIFF
--- a/src/color_ops.rs
+++ b/src/color_ops.rs
@@ -10,17 +10,17 @@ pub trait LuminanceOps: Sized {
 
     /// Return a darker version of this color. The `amount` should be between 0.0 and 1.0.
     /// The amount represents an absolute decrease in luminance, and is commutative:
-    /// `color.darken(a).darken(b) == color.darken(a + b)`.
+    /// `color.darker(a).darker(b) == color.darker(a + b)`.
     ///
     /// For a relative decrease in luminance, you can simply `mix()` with black.
-    fn darken(&self, amount: f32) -> Self;
+    fn darker(&self, amount: f32) -> Self;
 
     /// Return a lighter version of this color. The `amount` should be between 0.0 and 1.0.
     /// The amount represents an absolute increase in luminance, and is commutative:
-    /// `color.lighten(a).lighten(b) == color.lighten(a + b)`.
+    /// `color.lighter(a).lighter(b) == color.lighter(a + b)`.
     ///
     /// For a relative increase in luminance, you can simply `mix()` with white.
-    fn lighten(&self, amount: f32) -> Self;
+    fn lighter(&self, amount: f32) -> Self;
 }
 
 /// Linear interpolation of two colors within a given color space.

--- a/src/hsla.rs
+++ b/src/hsla.rs
@@ -102,14 +102,14 @@ impl LuminanceOps for Hsla {
         self.lightness
     }
 
-    fn darken(&self, amount: f32) -> Self {
+    fn darker(&self, amount: f32) -> Self {
         Self {
             lightness: (self.lightness - amount).max(0.),
             ..*self
         }
     }
 
-    fn lighten(&self, amount: f32) -> Self {
+    fn lighter(&self, amount: f32) -> Self {
         Self {
             lightness: (self.lightness + amount).min(1.),
             ..*self

--- a/src/lcha.rs
+++ b/src/lcha.rs
@@ -97,7 +97,7 @@ impl LuminanceOps for Lcha {
         self.lightness
     }
 
-    fn darken(&self, amount: f32) -> Self {
+    fn darker(&self, amount: f32) -> Self {
         Self::new(
             (self.lightness - amount).max(0.),
             self.chroma,
@@ -106,7 +106,7 @@ impl LuminanceOps for Lcha {
         )
     }
 
-    fn lighten(&self, amount: f32) -> Self {
+    fn lighter(&self, amount: f32) -> Self {
         Self::new(
             (self.lightness + amount).min(1.),
             self.chroma,

--- a/src/linear_rgba.rs
+++ b/src/linear_rgba.rs
@@ -105,14 +105,14 @@ impl LuminanceOps for LinearRgba {
     }
 
     #[inline]
-    fn darken(&self, amount: f32) -> Self {
+    fn darker(&self, amount: f32) -> Self {
         let mut result = *self;
         result.adjust_lightness(-amount);
         result
     }
 
     #[inline]
-    fn lighten(&self, amount: f32) -> Self {
+    fn lighter(&self, amount: f32) -> Self {
         let mut result = *self;
         result.adjust_lightness(amount);
         result
@@ -271,17 +271,17 @@ mod tests {
     }
 
     #[test]
-    fn darken_lighten() {
-        // Darken and lighten should be commutative.
+    fn darker_lighter() {
+        // Darker and lighter should be commutative.
         let color = LinearRgba::new(0.4, 0.5, 0.6, 1.0);
-        let darker1 = color.darken(0.1);
-        let darker2 = darker1.darken(0.1);
-        let twice_as_dark = color.darken(0.2);
+        let darker1 = color.darker(0.1);
+        let darker2 = darker1.darker(0.1);
+        let twice_as_dark = color.darker(0.2);
         assert!(darker2.distance_squared(&twice_as_dark) < 0.0001);
 
-        let lighter1 = color.lighten(0.1);
-        let lighter2 = lighter1.lighten(0.1);
-        let twice_as_light = color.lighten(0.2);
+        let lighter1 = color.lighter(0.1);
+        let lighter2 = lighter1.lighter(0.1);
+        let twice_as_light = color.lighter(0.2);
         assert!(lighter2.distance_squared(&twice_as_light) < 0.0001);
     }
 }

--- a/src/oklaba.rs
+++ b/src/oklaba.rs
@@ -92,11 +92,11 @@ impl LuminanceOps for Oklaba {
         self.l
     }
 
-    fn darken(&self, amount: f32) -> Self {
+    fn darker(&self, amount: f32) -> Self {
         Self::new((self.l - amount).max(0.), self.a, self.b, self.alpha)
     }
 
-    fn lighten(&self, amount: f32) -> Self {
+    fn lighter(&self, amount: f32) -> Self {
         Self::new((self.l + amount).min(1.), self.a, self.b, self.alpha)
     }
 }

--- a/src/srgba.rs
+++ b/src/srgba.rs
@@ -255,15 +255,15 @@ impl LuminanceOps for SRgba {
     }
 
     #[inline]
-    fn darken(&self, amount: f32) -> Self {
+    fn darker(&self, amount: f32) -> Self {
         let linear: LinearRgba = (*self).into();
-        linear.darken(amount).into()
+        linear.darker(amount).into()
     }
 
     #[inline]
-    fn lighten(&self, amount: f32) -> Self {
+    fn lighter(&self, amount: f32) -> Self {
         let linear: LinearRgba = (*self).into();
-        linear.lighten(amount).into()
+        linear.lighter(amount).into()
     }
 }
 
@@ -438,17 +438,17 @@ mod tests {
     }
 
     #[test]
-    fn darken_lighten() {
-        // Darken and lighten should be commutative.
+    fn darker_lighter() {
+        // Darker and lighter should be commutative.
         let color = SRgba::new(0.4, 0.5, 0.6, 1.0);
-        let darker1 = color.darken(0.1);
-        let darker2 = darker1.darken(0.1);
-        let twice_as_dark = color.darken(0.2);
+        let darker1 = color.darker(0.1);
+        let darker2 = darker1.darker(0.1);
+        let twice_as_dark = color.darker(0.2);
         assert!(darker2.distance_squared(&twice_as_dark) < 0.0001);
 
-        let lighter1 = color.lighten(0.1);
-        let lighter2 = lighter1.lighten(0.1);
-        let twice_as_light = color.lighten(0.2);
+        let lighter1 = color.lighter(0.1);
+        let lighter2 = lighter1.lighter(0.1);
+        let twice_as_light = color.lighter(0.2);
         assert!(lighter2.distance_squared(&twice_as_light) < 0.0001);
     }
 


### PR DESCRIPTION
Simple rename of the `lighten` and `darken` functions to `lighter` and `darker` for a more "fluent" interface.